### PR TITLE
Image output type for EPS

### DIFF
--- a/R/plantuml_knit_engine.R
+++ b/R/plantuml_knit_engine.R
@@ -68,7 +68,7 @@ plantuml_knit_engine <-  function(options) {
         "eps" = {
           fig_type <- "eps"
           fig_opt <- "-teps"
-          output_type <- "text"
+          output_type <- "image"
           fig <- paste0(options$label, ".", fig_type)
         },
         stop("Unsupported `plantuml.format`!")

--- a/R/plantuml_knit_engine.R
+++ b/R/plantuml_knit_engine.R
@@ -68,7 +68,7 @@ plantuml_knit_engine <-  function(options) {
         "eps" = {
           fig_type <- "eps"
           fig_opt <- "-teps"
-          output_type <- "image"
+          output_type <- ifelse(knitr::is_latex_output(), "image", "text")
           fig <- paste0(options$label, ".", fig_type)
         },
         stop("Unsupported `plantuml.format`!")

--- a/R/plantuml_knit_engine.R
+++ b/R/plantuml_knit_engine.R
@@ -7,7 +7,8 @@
 #'    At the moment, the following are supported:
 #'      - **png**	To generate image using PNG format (default).
 #'      - **svg**	To generate image using SVG format.
-#'      - **eps**	To generate text in EPS format.
+#'      - **eps**	To generate text in EPS format; or generates an image when
+#'      outputting LaTeX rather than HTML formats.
 #'  - **plantuml.path**: the path where the resulting files will be saved.
 #'    Default is the same directory as the `.Rmd` file is in. The path will be created if it does not exist.
 #'  - **plantuml.preview**: if `TRUE`, an inline preview will be shown in RStudio.


### PR DESCRIPTION
Output type of `"text"` injects the code of the EPS into the knit stream and becomes verbatim in the final PDF; pages of Adobe code. Seems more correct to apply `include_graphics`  to the resulting EPS file.